### PR TITLE
Changed test for polar term

### DIFF
--- a/pc-saft tests.py
+++ b/pc-saft tests.py
@@ -8,8 +8,7 @@ import numpy as np
 import timeit
 from pcsaft_electrolyte import pcsaft_den, pcsaft_hres, pcsaft_gres, pcsaft_sres, pcsaft_Hvap
 from pcsaft_electrolyte import pcsaft_vaporP, pcsaft_bubbleP, dielc_water, pcsaft_PTz, pcsaft_osmoticC
-from pcsaft_electrolyte import pcsaft_dadt, pcsaft_d2adt, pcsaft_dZdt, pcsaft_Z, pcsaft_dhdt
-from pcsaft_electrolyte import pcsaft_dgdt, pcsaft_dsdt, pcsaft_cp, pcsaft_ares
+from pcsaft_electrolyte import pcsaft_dadt, pcsaft_d2adt, pcsaft_cp, pcsaft_ares, pcsaft_p, pcsaft_fugcoef
 import pylab as pl
 
 def test_hres():
@@ -47,19 +46,19 @@ def test_hres():
     calc = pcsaft_hres(x, m, s, e, t, den, e_assoc=eAB, vol_a=volAB)
     print('Acetic acid, vapor:\t\t', calc, -15393.63, 'J/mol')
     
-    # Butyl acetate ---------
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])   
+    # dimethyl ether ---------
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
     
     den = pcsaft_den(x, m, s, e, t, p, phase='liq', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_hres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, liquid:\t', calc, -43443.19, 'J/mol')
+    print('dimethyl ether, liquid:\t', calc, -18242.5, 'J/mol')
     den = pcsaft_den(x, m, s, e, t, p, phase='vap', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_hres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, vapor:\t\t', calc, -516.4779, 'J/mol')
+    print('dimethyl ether, vapor:\t\t', calc, -89.6574, 'J/mol')
     
     return None
     
@@ -98,19 +97,19 @@ def test_sres():
     calc = pcsaft_sres(x, m, s, e, t, den, e_assoc=eAB, vol_a=volAB)
     print('Acetic acid, vapor:\t\t', calc, -40.8743, 'J/mol/K')
     
-    # Butyl acetate ---------
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])   
+    # dimethyl ether ---------
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
     
     den = pcsaft_den(x, m, s, e, t, p, phase='liq', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_sres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, liquid:\t', calc, -108.9615, 'J/mol/K')
+    print('dimethyl ether, liquid:\t', calc, -75.2232, 'J/mol/K')
     den = pcsaft_den(x, m, s, e, t, p, phase='vap', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_sres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, vapor:\t\t', calc, -1.0361, 'J/mol/K')
+    print('dimethyl ether, vapor:\t\t', calc, -0.17854, 'J/mol/K')
     
     return None
     
@@ -149,19 +148,19 @@ def test_gres():
     calc = pcsaft_gres(x, m, s, e, t, den, e_assoc=eAB, vol_a=volAB)
     print('Acetic acid, vapor:\t\t', calc, -2109.459, 'J/mol')
     
-    # Butyl acetate ---------
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])   
+    # dimethyl ether ---------
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
     
     den = pcsaft_den(x, m, s, e, t, p, phase='liq', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_gres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, liquid:\t', calc, -8030.709, 'J/mol')
+    print('dimethyl ether, liquid:\t', calc, -6205.02, 'J/mol')
     den = pcsaft_den(x, m, s, e, t, p, phase='vap', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_gres(x, m, s, e, t, den, dipm=dpm, dip_num=dip_num)
-    print('Butyl acetate, vapor:\t\t', calc, -179.7519, 'J/mol')
+    print('dimethyl ether, vapor:\t\t', calc, -31.6322, 'J/mol')
     
     return None
 
@@ -212,15 +211,15 @@ def test_density():
     print('    PC-SAFT:', calc, 'mol m^-3')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')  
     
-    # Butyl acetate
-    print('\n##########  Test with butyl acetate  ##########')
-    m = np.asarray([3.9706])
-    s = np.asarray([3.5440])
-    e = np.asarray([241.93])
-    dpm = np.asarray([1.86])
+    # dimethyl ether
+    print('\n##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
     dip_num = np.asarray([1.0])
     
-    ref = 8021. # source: DIPPR correlation
+    ref = 16110. # source: DIPPR correlation
     calc = pcsaft_den(x, m, s, e, 240, 101325, phase='liq', dipm=dpm, dip_num=dip_num)
     print('----- Density at 240 K and 101325 Pa -----')
     print('    Reference:', ref, 'mol m^-3')
@@ -323,16 +322,16 @@ def test_vaporP():
     print('    PC-SAFT:', calc, 'Pa')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')    
     
-#    # Butyl acetate
-    print('\n##########  Test with butyl acetate  ##########')
-    m = np.asarray([3.9706])
-    s = np.asarray([3.5440])
-    e = np.asarray([241.93])
-    dpm = np.asarray([1.86])
+#    # dimethyl ether
+    print('\n##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
     dip_num = np.asarray([1.0])
     
-    ref = 219.6 # source: DIPPR correlation
-    calc = pcsaft_vaporP(ref, x, m, s, e, 270, dipm=dpm, dip_num=dip_num)
+    ref = 625100. # source: DIPPR correlation
+    calc = pcsaft_vaporP(ref, x, m, s, e, 300, dipm=dpm, dip_num=dip_num)
     print('----- Vapor pressure at 270 K -----')
     print('    Reference:', ref, 'Pa')
     print('    PC-SAFT:', calc, 'Pa')
@@ -515,18 +514,18 @@ def test_Hvap():
     print('    PC-SAFT:', calc, 'J mol^-1')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')    
     
-    # Butyl acetate
-    print('\n##########  Test with butyl acetate  ##########')
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])
+    # dimethyl ether
+    print('\n##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
     
-    ref = 32280. # source: DIPPR correlation
-    p = 362200. # source: DIPPR correlation
-    calc = pcsaft_Hvap(p, x, m, s, e, 450., dipm=dpm, dip_num=dip_num)[0]
-    print('----- Enthalpy of vaporization at 450 K -----')
+    ref = 17410. # source: DIPPR correlation
+    p = 937300. # source: DIPPR correlation
+    calc = pcsaft_Hvap(p, x, m, s, e, 315., dipm=dpm, dip_num=dip_num)[0]
+    print('----- Enthalpy of vaporization at 315 K -----')
     print('    Reference:', ref, 'J mol^-1')
     print('    PC-SAFT:', calc, 'J mol^-1')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')     
@@ -604,13 +603,13 @@ def test_dadt():
     print('    PC-SAFT derivative:', dadt_eos)
     print('    Relative deviation:', (dadt_eos-dadt_num)/dadt_num*100, '%')   
     
-    # Butyl acetate    
-    print('##########  Test with butyl acetate  ##########')
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])
+    # dimethyl ether    
+    print('##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
 
     p = 100000.
     t = 370.
@@ -711,13 +710,13 @@ def test_d2adt():
     print('    PC-SAFT derivative:', d2adt_eos)
     print('    Relative deviation:', (d2adt_eos-d2adt_num)/d2adt_num*100, '%')   
     
-    # Butyl acetate    
-    print('##########  Test with butyl acetate  ##########')
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])
+    # dimethyl ether    
+    print('##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
 
     p = 100000.
     t = 370.
@@ -831,25 +830,23 @@ def test_cp():
     print('    PC-SAFT:', calc, 'J mol^-1 K^-1')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')    
     
-    # Butyl acetate
-    print('\n##########  Test with butyl acetate  ##########')
-    m = np.asarray([2.76462805])
-    s = np.asarray([4.02244938])
-    e = np.asarray([263.69902915])
-    dpm = np.asarray([1.84])
-    dip_num = np.asarray([4.99688339])
-    cnsts = np.asarray([116840., 376900, 1956, 281800, 811.2]) # constants for Aly-Lee equation (obtained from DIPPR)
+    # dimethyl ether
+    print('\n##########  Test with dimethyl ether  ##########')
+    m = np.asarray([2.2634])
+    s = np.asarray([3.2723])
+    e = np.asarray([210.29])
+    dpm = np.asarray([1.3])
+    dip_num = np.asarray([1.0])
+    cnsts = np.asarray([57431., 94494, 895.51, 65065, 2467.4]) # constants for Aly-Lee equation (obtained from DIPPR)
 
-    ref = 234.9 # source: DIPPR correlation
+    ref = 102.2 # source: DIPPR correlation
     p = 100000.
-    t = 320.
+    t = 240.
     rho = pcsaft_den(x, m, s, e, t, p, phase='liq', dipm=dpm, dip_num=dip_num)
     calc = pcsaft_cp(x, m, s, e, t, rho, cnsts, dipm=dpm, dip_num=dip_num)
-    print('----- Heat capacity at 320 K -----')
+    print('----- Heat capacity at 240 K -----')
     print('    Reference:', ref, 'J mol^-1 K^-1')
     print('    PC-SAFT:', calc, 'J mol^-1 K^-1')
     print('    Relative deviation:', (calc-ref)/ref*100, '%')     
     
     return None
-
-test_density()


### PR DESCRIPTION
The parameters for butyl acetate appeared to be wrong, so a test with dimethyl ether is now used instead.